### PR TITLE
Fix imperative mood false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Offers an interactive prompt if any of the rules are detected to be broken.
 At the root of the repository, run:
 
 ```sh
-curl https://cdn.rawgit.com/tommarshall/git-good-commit/v0.4.0/hook.sh > .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+curl https://cdn.rawgit.com/tommarshall/git-good-commit/v0.5.0/hook.sh > .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
 ```
 
 ### Globally
@@ -37,14 +37,14 @@ To use the hook globally, you can use `git-init`'s template directory:
 ```sh
 mkdir -p ~/.git-template/hooks
 git config --global init.templatedir '~/.git-template'
-curl https://cdn.rawgit.com/tommarshall/git-good-commit/v0.4.0/hook.sh > ~/.git-template/hooks/commit-msg && chmod +x ~/.git-template/hooks/commit-msg
+curl https://cdn.rawgit.com/tommarshall/git-good-commit/v0.5.0/hook.sh > ~/.git-template/hooks/commit-msg && chmod +x ~/.git-template/hooks/commit-msg
 ```
 
 The hook will now be present after any `git init` or `git clone`. You can [safely re-run `git init`](http://stackoverflow.com/a/5149861/885540) on any existing repositories to add the hook there.
 
 ---
 
-_If you're security conscious, you may be reasonably suspicious of [curling executable files](https://www.seancassidy.me/dont-pipe-to-your-shell.html). In this case you're on HTTPS throughout, and not piping directly to execution, so you can check contents and the hash against MD5 `1bbe22e756fe98dbcc8aae390e20367d` for v0.4.0._
+_If you're security conscious, you may be reasonably suspicious of [curling executable files](https://www.seancassidy.me/dont-pipe-to-your-shell.html). In this case you're on HTTPS throughout, and not piping directly to execution, so you can check contents and the hash against MD5 `32345e70572846c29f3a767c3dce492f` for v0.5.0._
 
 ## Usage
 

--- a/hook.sh
+++ b/hook.sh
@@ -4,7 +4,7 @@
 # git-good-commit(1) - Git hook to help you write good commit messages.
 # Released under the MIT License.
 #
-# Version 0.4.0
+# Version 0.5.0
 #
 # https://github.com/tommarshall/git-good-commit
 #

--- a/hook.sh
+++ b/hook.sh
@@ -180,7 +180,7 @@ validate_commit_message() {
   shopt -s nocasematch
 
   for BLACKLISTED_WORD in "${IMPERATIVE_MOOD_BLACKLIST[@]}"; do
-    [[ ${COMMIT_SUBJECT} =~ $BLACKLISTED_WORD ]]
+    [[ ${COMMIT_SUBJECT} =~ ^[[:blank:]]*$BLACKLISTED_WORD ]]
     test $? -eq 0 && add_warning 1 "Use the imperative mood in the subject line, e.g 'fix' not 'fixes'" && break
   done
 

--- a/test/validation.bats
+++ b/test/validation.bats
@@ -172,15 +172,15 @@ EOF
 # 5. Use the imperative mood in the subject line
 # ------------------------------------------------------------------------------
 
-@test "validation: subject line with 'fixes' shows warning" {
+@test "validation: subject line starting with 'fixes' shows warning" {
   echo "n" > $FAKE_TTY
-  run git commit -m "More fixes for broken stuff"
+  run git commit -m "Fixes for broken stuff"
 
   assert_failure
   assert_line --partial "Use the imperative mood in the subject line"
 }
 
-@test "validation: subject line with 'fixed' shows warning" {
+@test "validation: subject line starting with 'fixed' shows warning" {
   echo "n" > $FAKE_TTY
   run git commit -m "Fixed bug with Y"
 
@@ -188,12 +188,20 @@ EOF
   assert_line --partial "Use the imperative mood in the subject line"
 }
 
-@test "validation: subject line with 'fixing' shows warning" {
+@test "validation: subject line starting with 'fixing' shows warning" {
   echo "n" > $FAKE_TTY
   run git commit -m "Fixing behavior of X"
 
   assert_failure
   assert_line --partial "Use the imperative mood in the subject line"
+}
+
+@test "validation: subject line in imperative mood with 'fixes' does not show warning" {
+  echo "n" > $FAKE_TTY
+  run git commit -m "Remove the temporary fixes to Y"
+
+  assert_success
+  refute_line --partial "Use the imperative mood in the subject line"
 }
 
 @test "validation: body with 'fixes', 'fixed', 'fixing' does not show warning" {


### PR DESCRIPTION
#### Because:

* The imperative mood check is incorrectly reporting a warning when a
  commit subject is in imperative mood, but contains a word on the
  blacklist, e.g. "Remove the temporary fixes to foo"
* This is because the check is currently checking for the presence of
  the blacklist words anywhere in the string.

#### This change:

* Add test for the false positive case.
* Fix the issue by having the check test only the first word of the
  subject against the blacklist.

#### Notes:

* This may lead to some false negatives, but it's best effort, and the
  false positives are coming up relatively frequently.

Fixes #6 