### PR TITLE
Added `make install` and `make repair` targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+CURDIR:=$(shell pwd)
+
 setup:
 	@rm -rf vendor
 	@mkdir -p vendor
@@ -7,5 +9,13 @@ setup:
 
 test:
 	vendor/bats/bin/bats test
+
+install:
+	mkdir -p ~/.git-template/hooks
+	git config --global init.templatedir '~/.git-template'
+	cp -f hook.sh ~/.git-template/hooks/commit-msg
+
+repair:
+	find ~/ -name .git -type d -prune | xargs -I '{}' sh -c "[ ! -f '{}/hooks/commit-msg' ] && ln -s -f $(CURDIR)/hook.sh '{}/hooks/commit-msg' || true;"
 
 .PHONY: setup test


### PR DESCRIPTION
Make install will install the hook globally and make repair will install the hook on all existing git repos in the user home directory (recursive find).