### PR TITLE
Fix non-interactive usage

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -284,6 +284,11 @@ while true; do
 
   display_warnings
 
+  # if non-interactive don't prompt and exit with an error
+  if [ ! -t 1 ] && [ -z ${FAKE_TTY+x} ]; then
+    exit 1
+  fi
+
   # Ask the question (not using "read -p" as it uses stderr not stdout)
   echo -en "${BLUE}Proceed with commit? [e/y/n/?] ${NC}"
 


### PR DESCRIPTION
#### Because:

* Currently, the hook will always prompt for user input if warnings are
  detected.
* This prevents usage in non-interactive contexts such as some Git GUI
  clients and CI.

#### Notes:

* I don't love the test specific `FAKE_TTY` featuring in the hook
  itself, but I can't think of a way around this right now and I think
  the non-interactive support is worth it.

Credit to @ssbarnea for the solution, ref: https://github.com/tommarshall/git-good-commit/pull/18

Fixes #17