### PR TITLE
Add support for verbose commits

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -111,6 +111,10 @@ read_commit_message() {
     REPLY="${REPLY%%*( )}"
     shopt -u extglob
 
+    # ignore all lines after cut line
+    [[ $REPLY == "# ------------------------ >8 ------------------------" ]]
+    test $? -eq 1 || break
+
     # ignore comments
     [[ $REPLY =~ ^# ]]
     test $? -eq 0 || COMMIT_MSG_LINES+=("$REPLY")


### PR DESCRIPTION
Break the reading of commit message lines if we find a cut line.
This makes the validator ignore lines part of the commit diff in verbose
mode. Which will make the check faster, and not give warnings if lines
in your code exceed 72 characters.