### PR TITLE
Add spelling check

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -140,6 +140,22 @@ validate_commit_message() {
   # if the commit subject starts with 'fixup! ' there's nothing to validate, we can return here
   [[ $COMMIT_SUBJECT == 'fixup! '* ]] && return;
 
+
+  # 0. Check spelling
+  # ------------------------------------------------------------------------------
+  ASPELL=$(which aspell)
+  if [ $? -ne 0 ]; then
+      echo "Aspell not installed - unable to check spelling"
+  else
+    for i in "${!v}"; do
+      LINE_NUMBER=$((i+1))
+      MISSPELLED_WORDS=`echo "$COMMIT_MSG_LINES[LINE_NUMBER]" | $ASPELL --list`
+      if [ -n "$MISSPELLED_WORDS" ]; then
+        add_warning LINE_NUMBER "Possible misspelled word(s): $MISSPELLED_WORDS"
+      fi
+    done
+  fi
+
   # 1. Separate subject from body with a blank line
   # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
I am trying to add a spelling check to the git hook.

Warning: this is a first shot which is not correctly working!
- Last line of the message commit is not checked
- If several words have a typo, only the first one is shown

@tommarshall Would you like to add the spelling check or you'd rather stick to initial post to write good commit. I don't have any shell experience and I didn't manage to make it work properly, any help would be welcomed ;)

I loosely took inspiration from this [gist](https://gist.github.com/homam/58a7e98f8fdb0f3034ee).