### PR TITLE
Clarify prompt text for editing commit message

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -296,7 +296,7 @@ while true; do
   fi
 
   # Ask the question (not using "read -p" as it uses stderr not stdout)
-  echo -en "${BLUE}Proceed with commit? [e/y/n/?] ${NC}"
+  echo -en "${BLUE}Would you like to commit anyway? [e/y/n/?] ${NC}"
 
   # Read the answer
   read REPLY < "$TTY"


### PR DESCRIPTION
I was seeing some confusion from other developers in my project with the
previous prompt. It was unclear / confusing what "y" and "no" correspond
to with the previous prompt. This new version seems slightly clearer and
reduces mental friction.
